### PR TITLE
TASK: compatibility with Neos 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "neos/flow": "^7.0 || ^8.0",
+        "neos/flow": "^7.0 || ^8.0 || ^9.0 || dev-master",
         "microsoft/azure-storage-blob": "^1.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "neos/flow": "^7.0 || ^8.0 || ^9.0 || dev-master",
+        "neos/flow": "^7.0 || ^8.0 || ^9.0 || dev-main",
         "microsoft/azure-storage-blob": "^1.5"
     },
     "autoload": {


### PR DESCRIPTION
For updating to Neos 9.0 the version needs to be updated. 

As far as I can see on my local machine the package works fine with Neos 9.0. Perhaps someone else can verify with a Neos 9.0 installation.  